### PR TITLE
Bugfix #1, Allow Postgres to upgrade to version 14

### DIFF
--- a/sql/sql_routines.sql
+++ b/sql/sql_routines.sql
@@ -69,10 +69,10 @@ CREATE AGGREGATE weighted_stddev(var numeric, weight numeric)
 );
 COMMENT ON AGGREGATE weighted_stddev(numeric, numeric) IS 'Usage: select weighted_stddev(var::numeric, weight::numeric) from X;';
 
-CREATE AGGREGATE array_accum (anyarray)
+CREATE AGGREGATE array_accum (anycompatiblearray)
 (
     sfunc = array_cat,
-    stype = anyarray,
+    stype = anycompatiblearray,
     initcond = '{}'
 );
 

--- a/sql/update_postgres_10_to_14.sql
+++ b/sql/update_postgres_10_to_14.sql
@@ -1,0 +1,8 @@
+DROP AGGREGATE array_accum (anyarray);
+
+CREATE AGGREGATE array_accum (anycompatiblearray)
+(
+    sfunc = array_cat,
+    stype = anycompatiblearray,
+    initcond = '{}'
+);


### PR DESCRIPTION
For existing database instances, after upgrading to version 14, run the update_postgres_10_to_14.sql script then restart the database.

For fresh postgres 14 database instances update_postgres_10_to_14.sql can be ignored as the changes to sql_routines.sql will fix the issue.